### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -2,6 +2,8 @@
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-nodejs
 
 name: Node.js CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/seongjin605/arehs/security/code-scanning/2](https://github.com/seongjin605/arehs/security/code-scanning/2)

In general, the fix is to explicitly declare a minimal `permissions` block in the workflow, either at the root (applying to all jobs) or inside the `build` job. For this workflow, the job only needs to check out code, set up Node, install dependencies, build, and test; that requires only read access to repository contents. So we can add `permissions: contents: read` at the top level, which will apply to the `build` job and avoid changing any existing behavior.

The best minimal change is to insert a root-level `permissions` block after the `name: Node.js CI` line and before the `on:` block in `.github/workflows/node.js.yml`. No additional imports or external actions are required, and no existing steps need modification. The workflow will behave the same, but `GITHUB_TOKEN` will be restricted to read-only access to repository contents unless more scopes are explicitly added later.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
